### PR TITLE
Fix for Settings menu item is invisible #64

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -19,6 +19,7 @@
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
         <item name="colorAccent">@color/colorAccent</item>
+        <item name="android:textColor">@color/colorPrimary</item>
     </style>
 
 </resources>


### PR DESCRIPTION
Added textColor attribute in styles.xml. Settings menu item was shown invisible because of the Light Material theme used in the project. Text color become white under the above scenario.